### PR TITLE
sparse matrix BB is not assembled with Hermetian transpose of BB_U

### DIFF
--- a/VoldKalmanFilter.py
+++ b/VoldKalmanFilter.py
@@ -193,7 +193,7 @@ def vkf(y,fs,f,p=None,bw=None,multiorder=None,solver='scipy-spsolve'):
 
         ii_U = np.zeros((n_t,bl_U))
         jj_U = np.zeros((n_t,bl_U))
-        cc_U = np.zeros((n_t,bl_U),dtype = np.float64)
+        cc_U = np.zeros((n_t,bl_U),dtype = np.complex128)
         m = 0
         
         #Upper-diagonal part
@@ -201,14 +201,14 @@ def vkf(y,fs,f,p=None,bw=None,multiorder=None,solver='scipy-spsolve'):
             for kj in range((ki+1),n_ord):
                 ii_U[:,m] = (ki)*n_t + np.arange(0,n_t)
                 jj_U[:,m] = (kj)*n_t + np.arange(0,n_t)
-                cc_U[:,m] = np.real(np.conj(c[:,ki])*c[:,kj])
+                cc_U[:,m] = np.conj(c[:,ki])*c[:,kj]
                 m = m + 1
 
         #Construct sparse upper-diagonal part
         BB_U = sparse.csr_matrix((cc_U.flatten(),(ii_U.flatten(),jj_U.flatten())),shape=(nn,nn))
         
         #Assemble sparse matrix
-        BB = BB_D + BB_U + BB_U.transpose()
+        BB = BB_D + BB_U + BB_U.getH()
 
         #Construct right-hand side
         cy = (np.conj(c.T.reshape(-1,1)).T*np.tile(y,(n_ord))).T


### PR DESCRIPTION
The assembled sparse matrix BB is not created with the Hermitian transpose of BB_U. This leads to significant performance differences for higher orders compared to the Matlab implementation. I changed the datatype of cc_U and neglected the np.real() command in the for-loop to keep it in line with the Matlab implementation. Additionally, the method .transpose() just changes matrix dimensions, but does not change the sign of the matrix's imaginary part, so to keep the matrix operation of BB_U analogous to Matlab's Hermetian transpose operation BB_U', I used BB_U.getH().